### PR TITLE
Develop

### DIFF
--- a/annotation_tool/views.py
+++ b/annotation_tool/views.py
@@ -116,6 +116,16 @@ class AnnotationView(SuperuserRequiredMixin, DestroyAPIView):
             return Response({'result': 'deleted'})
 
 
+def check_all_events_with_name(events):
+    all_right = True
+
+    for e in events:
+        if not e.event_class:
+            all_right = False
+
+    return all_right
+
+
 class AnnotationFinishView(LoginRequiredMixin, GenericAPIView):
     queryset = models.Annotation.objects.all()
     lookup_field = 'id'
@@ -123,45 +133,62 @@ class AnnotationFinishView(LoginRequiredMixin, GenericAPIView):
     def post(self, request, *args, **kwargs):
         annotation = self.get_object()
         regions = models.Region.objects.filter(annotation=annotation)
-        if not regions:
-            events = models.Event.objects.filter(annotation=annotation)
+        events = models.Event.objects.filter(annotation=annotation)
 
-            segment = annotation.segment
+        if check_all_events_with_name(events) or len(events) == 0:
+            if not regions:
+                # for e in regions:
+                #     logging.debug(e )
 
-            for e in events:
-                region = models.Region(annotation=annotation,
-                                       start_time=e.start_time,
-                                       end_time=e.end_time,
-                                       color=e.color)
-                for t in e.tags.values_list('name'):
-                    tag = models.Tag.objects.get_or_create(name=t)
-                    region.tags.add(tag[0])
-                region.save()
-                cp = models.ClassProminence(region=region,
-                                            class_obj=e.event_class,
-                                            prominence=5)
-                cp.save()
-                utils.region_to_wav(annotation, segment, region, e.event_class)
 
-        utils.update_annotation_status(annotation,
-                                       new_status=models.Annotation.FINISHED)
+                segment = annotation.segment
 
-        # find unfinished annotation for current project
-        project = annotation.get_project()
-        segment = utils.pick_segment_to_annotate(project.name, request.user.id)
+                # if check_all_events_with_name(events):
+                for e in events:
+                    region = models.Region(annotation=annotation,
+                                           start_time=e.start_time,
+                                           end_time=e.end_time,
+                                           color=e.color)
+                    for t in e.tags.values_list('name'):
+                        tag = models.Tag.objects.get_or_create(name=t)
+                        region.tags.add(tag[0])
+                    region.save()
+                    cp = models.ClassProminence(region=region,
+                                                class_obj=e.event_class,
+                                                prominence=5)
+                    cp.save()
 
-        next_annotation_url = ''
-        if not segment:
-            return JsonResponse({'next_annotation_url':next_annotation_url})
-        elif request.data.get('load next') == '1':
-            # if have unannotated segment
-            next_annotation = utils.create_annotation(segment, request.user)
-            next_annotation_url = '{}?project={}&annotation={}'.format(reverse('new_annotation'),
-                                                                       project.id,
-                                                                       next_annotation.id)
-            return Response(data={'next_annotation_url': next_annotation_url}, status=status.HTTP_200_OK)
+                    # if e.event_class:
+                    #     logging.debug(e.event_class)
+
+
+                    # utils.region_to_wav(annotation, segment, region, e.event_class)
+
+                utils.update_annotation_status(annotation,
+                                               new_status=models.Annotation.FINISHED)
+
+                # find unfinished annotation for current project
+                project = annotation.get_project()
+                segment = utils.pick_segment_to_annotate(project.name, request.user.id)
+
+                next_annotation_url = ''
+                if not segment:
+                    return JsonResponse({'next_annotation_url': next_annotation_url})
+                elif request.data.get('load next') == '1':
+                    # if have unannotated segment
+                    next_annotation = utils.create_annotation(segment, request.user)
+                    next_annotation_url = '{}?project={}&annotation={}'.format(reverse('new_annotation'),
+                                                                               project.id,
+                                                                               next_annotation.id)
+                    return Response(data={'next_annotation_url': next_annotation_url}, status=status.HTTP_200_OK)
+
         else:
-            return JsonResponse({})
+            project = annotation.get_project()
+
+            current_annotation_url = '{}?project={}&annotation={}'.format(reverse('new_annotation'),
+                                                                        project.id,
+                                                                        annotation.id)
+            return Response(data={'next_annotation_url': current_annotation_url}, status=status.HTTP_200_OK)
 
 
 class ClassesView(SuperuserRequiredMixin, GenericAPIView):
@@ -494,12 +521,14 @@ def create_region(request):
     for t in region_data['tags']:
         tag = models.Tag.objects.get_or_create(name=t)
         region.tags.add(tag[0])
+
     region.save()
 
     for class_name in region_data['classes'].split():
         class_obj = models.Class.objects.get(name=class_name)
         class_prominence = models.ClassProminence(region=region,
                                                   class_obj=class_obj)
+
         class_prominence.save()
 
     return JsonResponse({'region_id': region.id})

--- a/chunks/.gitignore
+++ b/chunks/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
Trabajo realizado:

1. Creación de chunks inexacta

Antes: se creaban chunks de más. Esto era debido a que se comenzaban a crear chunks hasta que aparecía alguna excepción no controlada. En este caso, la existencia de fragmentos sin etiquetar con alguna clase. Esto generaba que la anotación no se cerrase, y que se pudiera seguir editando, modificándola, y dándole nuevamente a finalizar anotación, lo que creaba nuevos chunks duplicados.
Ahora: no se crean chunks hasta que la anotación está completamente cerrada. Es decir, en estado FINISHED.
2. ¿Qué era un fragmento sin finalizar?

Antes: Cualquier fragmento que se hubiera quedado a medias ( lógico ) y cualquier fragmento en el que hubiera ocurrido algún error por excepciones no controladas ( no debería ser posible )
Ahora: Los fragmentos sin finalizar son aquellos que el usuario únicamente ha dejado a medias, abandonando la pantalla antes de clickar finalizar.
NOTA: El usuario puede finalizar un fragmento sin haber seleccionado ningún segmento. ( Creo que se puede dar la situación y se debe controlar ).
3. Errores al finalizar anotaciones:

Antes: podías "finalizar" la anotación y pasar a la siguiente aunque hubiera errores, como que el usuario hubiera dejado un fragmento de audio sin etiquetar con una clase.
Ahora: no se permite al usuario avanzar a la siguiente anotación a no ser que todos los fragmentos hayan sido correctamente etiquetados.
4. Mejoras de usabilidad al etiquetar fragmentos.

Antes: Para acceder a los fragmentos sin finalizar, había que ir a my annotations. Y acceder a los finalizados. Si le dábamos a finalizar ese fragmento e ir al siguiente, nos notificaba que se habían acabado los fragmentos. ( cuando podía haber fragmentos sin finalizar )
Ahora: Cuando hacemos click en finalizar y pasar al siguiente, primero se busca fragmentos que se hayan quedado pendientes, si no hay ninguno, se crea un nuevo fragmento si lo hubiera, y si no se notifica al usuario de que ha terminado.